### PR TITLE
remove unnecessary brackets around destructuring

### DIFF
--- a/src/ring/middleware/ssl.clj
+++ b/src/ring/middleware/ssl.clj
@@ -39,7 +39,7 @@
 
   :ssl-port - the SSL port to use for redirects, defaults to 443."
   {:arglists '([handler] [handler options])}
-  [handler & [{:keys [ssl-port]}]]
+  [handler & {:keys [ssl-port]}]
   (fn [request]
     (if (= (:scheme request) :https)
       (handler request)


### PR DESCRIPTION
When using this middleware with a ssl port other than 443 it fails.  The ssl-port is not being read with the brackets around the destructure map.